### PR TITLE
Add Potomac Yard/C11 station to the UI

### DIFF
--- a/src/blue_stations.json
+++ b/src/blue_stations.json
@@ -181,6 +181,24 @@
       }
     },
     {
+      "Code": "C11",
+      "Name": "Potomac Yard",
+      "StationTogether1": "",
+      "StationTogether2": "",
+      "LineCode1": "BL",
+      "LineCode2": "YL",
+      "LineCode3": null,
+      "LineCode4": null,
+      "Lat": 38.83108,
+      "Lon": -77.04644,
+      "Address": {
+        "Street": "2900 Potomac Greens Drive",
+        "City": "Alexandria",
+        "State": "VA",
+        "Zip": "22314"
+      }
+    },
+    {
       "Code": "C12",
       "Name": "Braddock Road",
       "StationTogether1": "",

--- a/src/components/Line.js
+++ b/src/components/Line.js
@@ -699,8 +699,11 @@ export default createReactClass({
           <BetweenStationRow code={'C09_C10'} isOnLeft={true} />
           <BetweenStationRow code={'C10_C09'} isOnLeft={false} />
           <StationRow isDarkMode={this.props.isDarkMode} stationName={"Ronald Reagan Washington National Airport"} stationCode={"C10"} ref="C10" onClick={this._handleClickStation.bind(null, "Ronald Reagan Washington National Airport", "C10")} stationTwitterOnClick={this._handleClickStationTwitter.bind(null, "Ronald Reagan Washington National Airport", "C10")} onTapOutage={this._handleTapOutage.bind(null, "Ronald Reagan Washington National Airport", "C10")} />
-          <BetweenStationRow code={'C10_C12'} isOnLeft={true} />
-          <BetweenStationRow code={'C12_C10'} isOnLeft={false} />
+          <BetweenStationRow code={'C10_C11'} isOnLeft={true} />
+          <BetweenStationRow code={'C11_C10'} isOnLeft={false} />
+          <StationRow isDarkMode={this.props.isDarkMode} stationName={"Potomac Yard"} stationCode={"C11"} ref="C11" onClick={this._handleClickStation.bind(null, "Potomac Yard", "C11")} stationTwitterOnClick={this._handleClickStationTwitter.bind(null, "Potomac Yard", "C11")} onTapOutage={this._handleTapOutage.bind(null, "Potomac Yard", "C11")} />
+          <BetweenStationRow code={'C11_C12'} isOnLeft={true} />
+          <BetweenStationRow code={'C12_C11'} isOnLeft={false} />
           <StationRow isDarkMode={this.props.isDarkMode} stationName={"Braddock Road"} stationCode={"C12"} ref="C12" onClick={this._handleClickStation.bind(null, "Braddock Road", "C12")} stationTwitterOnClick={this._handleClickStationTwitter.bind(null, "Braddock Road", "C12")} onTapOutage={this._handleTapOutage.bind(null, "Braddock Road", "C12")} />
           <BetweenStationRow code={'C12_C13'} isOnLeft={true} />
           <BetweenStationRow code={'C13_C12'} isOnLeft={false} />
@@ -766,8 +769,11 @@ export default createReactClass({
           <BetweenStationRow code={'C09_C10'} isOnLeft={true} />
           <BetweenStationRow code={'C10_C09'} isOnLeft={false} />
           <StationRow isDarkMode={this.props.isDarkMode} stationName={"Ronald Reagan Washington National Airport"} stationCode={"C10"} ref="C10" onClick={this._handleClickStation.bind(null, "Ronald Reagan Washington National Airport", "C10")} stationTwitterOnClick={this._handleClickStationTwitter.bind(null, "Ronald Reagan Washington National Airport", "C10")} onTapOutage={this._handleTapOutage.bind(null, "Ronald Reagan Washington National Airport", "C10")} />
-          <BetweenStationRow code={'C10_C12'} isOnLeft={true} />
-          <BetweenStationRow code={'C12_C10'} isOnLeft={false} />
+          <BetweenStationRow code={'C10_C11'} isOnLeft={true} />
+          <BetweenStationRow code={'C11_C10'} isOnLeft={false} />
+          <StationRow isDarkMode={this.props.isDarkMode} stationName={"Potomac Yard"} stationCode={"C11"} ref="C11" onClick={this._handleClickStation.bind(null, "Potomac Yard", "C11")} stationTwitterOnClick={this._handleClickStationTwitter.bind(null, "Potomac Yard", "C11")} onTapOutage={this._handleTapOutage.bind(null, "Potomac Yard", "C11")} />
+          <BetweenStationRow code={'C11_C12'} isOnLeft={true} />
+          <BetweenStationRow code={'C12_C11'} isOnLeft={false} />
           <StationRow isDarkMode={this.props.isDarkMode} stationName={"Braddock Road"} stationCode={"C12"} ref="C12" onClick={this._handleClickStation.bind(null, "Braddock Road", "C12")} stationTwitterOnClick={this._handleClickStationTwitter.bind(null, "Braddock Road", "C12")} onTapOutage={this._handleTapOutage.bind(null, "Braddock Road", "C12")} />
           <BetweenStationRow code={'C12_C13'} isOnLeft={true} />
           <BetweenStationRow code={'C13_C12'} isOnLeft={false} />

--- a/src/yellow_stations.json
+++ b/src/yellow_stations.json
@@ -73,6 +73,24 @@
       }
     },
     {
+      "Code": "C11",
+      "Name": "Potomac Yard",
+      "StationTogether1": "",
+      "StationTogether2": "",
+      "LineCode1": "BL",
+      "LineCode2": "YL",
+      "LineCode3": null,
+      "LineCode4": null,
+      "Lat": 38.83108,
+      "Lon": -77.04644,
+      "Address": {
+        "Street": "2900 Potomac Greens Drive",
+        "City": "Alexandria",
+        "State": "VA",
+        "Zip": "22314"
+      }
+    },
+    {
       "Code": "C12",
       "Name": "Braddock Road",
       "StationTogether1": "",


### PR DESCRIPTION
This PR adds Potomac Yard into the fronte nd of the MH application. Modifications to the backend are required to tie the station to circuits, so that trains look like they're boarding at the right location.
<img width="351" alt="image" src="https://github.com/srepetsk/metrohero-webapp/assets/994289/dea4e02a-4a7e-4c74-aef7-a50b00b81789">
